### PR TITLE
Upstream changes from 1.2.X

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: hxii
 Tags: yotpo, shortcode, shortcodes, yotpo add-on, yotpo shortcodes, shortcodes for yotpo
 Requires at least: 4.6
 Requires PHP: 5.6
-Tested up to: 5.2
-Stable tag: 1.1.5
+Tested up to: 5.3
+Stable tag: 1.1.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ Get in touch, and I'll see what can be done.
 == Screenshots ==
 1. Example usage of the shortcodes.
 == Changelog ==
+= 1.1.6 =
+* Updated the code to be used with Yotpo Reviews for WooCommerce version 2.0 (https://github.com/hxii/YRFW).
+* Checked with WC 3.7.0 and WP 5.3 (5.3-alpha-45923).
 = 1.1.5 =
 * Checked with WC 3.6.2 and WP 5.2
 * Minor fixes and cleanup

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: hxii
 Tags: yotpo, shortcode, shortcodes, yotpo add-on, yotpo shortcodes, shortcodes for yotpo
 Requires at least: 4.6
-Requires PHP: 5.6
+Requires PHP: 7.0
 Tested up to: 5.3
 Stable tag: 1.2.0
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: yotpo, shortcode, shortcodes, yotpo add-on, yotpo shortcodes, shortcodes f
 Requires at least: 4.6
 Requires PHP: 7.0
 Tested up to: 5.3
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,9 +47,15 @@ Get in touch, and I'll see what can be done.
 == Screenshots ==
 1. Example usage of the shortcodes.
 == Changelog ==
+= 1.2.1 =
+* Code cleanup.
+* Added review highlights widget `[yotpo_highlights]` with optional `product_id` argument.
+* Added Q&A widget `[yotpo_questions]` with optional `product_id` argument.
+= 1.2.0 =
+* Now using Yotpo Reviews for WooCommerce (YRFW) as requirement.
 = 1.1.6 =
-* Updated the code to be used with Yotpo Reviews for WooCommerce version 2.0 (https://github.com/hxii/YRFW).
-* Checked with WC 3.7.0 and WP 5.3 (5.3-alpha-45923).
+* Showing notice to warn users prior to updating to 1.2.X versions.
+* Checked with latest version of WP.
 = 1.1.5 =
 * Checked with WC 3.6.2 and WP 5.2
 * Minor fixes and cleanup

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: yotpo, shortcode, shortcodes, yotpo add-on, yotpo shortcodes, shortcodes f
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 5.3
-Stable tag: 1.1.6
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/wc_yotpo_shortcodes.php
+++ b/wc_yotpo_shortcodes.php
@@ -2,12 +2,12 @@
 /*
 * Plugin Name: Shortcodes for Yotpo
 * Description: This plugin adds the ability to use shortcodes to control the placement of Yotpo widgets.
-* Version: 1.1.5
+* Version: 1.2.0
 * Author: Paul Glushak
 * Author URI: http://paulglushak.com/
 * Plugin URI: http://paulglushak.com/shortcodes-for-yotpo/
 * WC requires at least: 3.1.0
-* WC tested up to: 3.6.2
+* WC tested up to: 3.7.0
 */
 
 /*
@@ -15,68 +15,43 @@
  * See example usage at the bottom.
 */
 
-// if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
-defined( 'ABSPATH' ) or die();
+defined( 'ABSPATH' ) || die();
 
 /**
  * Shortcodes!
  */
-class Yotpo_Shortcodes
-{
+class Yotpo_Shortcodes {
 
-	function __construct()
-	{
-		$this->init_shortcodes();
-	}
-
-	function init_shortcodes() {
-		add_shortcode( 'yotpo_widget', array( $this, 'yotpo_widget' ) );
-		add_shortcode( 'yotpo_bottomline', array( $this, 'yotpo_bottomline' ) );
-		add_shortcode( 'yotpo_product_gallery', array( $this, 'yotpo_product_gallery' ) );
-		add_shortcode( 'yotpo_product_reviews_carousel', array( $this, 'yotpo_product_reviews_carousel' ) );
-		add_shortcode( 'yotpo_badge', array( $this, 'yotpo_badge' ) );
-		add_shortcode( 'yotpo_testimonials', array( $this, 'yotpo_testimonials' ) );
-	}
 	/**
-	 * Basic dependency check, to be replaced with class requirement
+	 * Run the init function on construction via action
+	 */
+	public function __construct() {
+		add_action( 'plugins_loaded', array( $this, 'init_shortcodes' ) );
+	}
+
+	/**
+	 * Registers all the shortcodes in WP
 	 *
 	 * @return void
-	 **/
-	private function basic_check() {
-		if ( !class_exists( 'woocommerce' ) ) {
-			return;
-		} elseif ( !function_exists( 'wc_yotpo_get_product_data' ) ) {
-			$plugins = get_option( 'active_plugins', array() );
-			if ( array_search('wc_yotpo.php', $plugins) ) {
-				require_once( ABSPATH . 'wp-content/plugins/yotpo-social-reviews-for-woocommerce/wc_yotpo.php' );
-			} else {
-				die();
-			}
+	 */
+	public function init_shortcodes() {
+		if ( class_exists( 'YRFW_Reviews' ) ) {
+			add_shortcode( 'yotpo_widget', array( $this, 'yotpo_widget' ) );
+			add_shortcode( 'yotpo_bottomline', array( $this, 'yotpo_bottomline' ) );
+			add_shortcode( 'yotpo_product_gallery', array( $this, 'yotpo_product_gallery' ) );
+			add_shortcode( 'yotpo_product_reviews_carousel', array( $this, 'yotpo_product_reviews_carousel' ) );
+			add_shortcode( 'yotpo_badge', array( $this, 'yotpo_badge' ) );
+			add_shortcode( 'yotpo_testimonials', array( $this, 'yotpo_testimonials' ) );
 		}
 	}
 
+	/**
+	 * Show main widget
+	 *
+	 * @param array $args product_id argument.
+	 * @return string
+	 */
 	public function yotpo_widget( $args ) {
-		$this->basic_check();
-		if ( isset( $args['product_id'] ) ) { $product_id = $args['product_id']; } elseif ( is_product() ) { global $product; $product_id = $product->get_id(); } else { return; }
-		$_product = wc_get_product( $product_id );
-		if ( is_null( $_product ) || !$_product ) { return; }
-		$widget_product_data = wc_yotpo_get_product_data( $_product );
-		$html = "<div class='yotpo yotpo-main-widget'
-	   				data-product-id='{$product_id}'
-	   				data-name='{$widget_product_data['title']}'
-	   				data-url='{$widget_product_data['url']}'
-	   				data-image-url='{$widget_product_data['image-url']}'
-	  				data-description='{$widget_product_data['description']}'
-	  				data-lang='{$widget_product_data['lang']}'
-	                data-price='{$_product->get_price()}'
-	                data-currency='".get_woocommerce_currency()."'></div>";
-		return $html;
-	}
-
-	public function yotpo_bottomline( $args ) {
-		$this->basic_check();
-		if ( !class_exists( 'Yotpo' ) ) { require_once( ABSPATH . 'wp-content/plugins/yotpo-social-reviews-for-woocommerce/lib/yotpo-api/Yotpo.php' ); }
-		$yotpo_settings = get_option( 'yotpo_settings' );
 		if ( isset( $args['product_id'] ) ) {
 			$product_id = $args['product_id'];
 		} elseif ( is_product() ) {
@@ -85,29 +60,70 @@ class Yotpo_Shortcodes
 		} else {
 			return;
 		}
-		$data = array();
-		$data['product_id'] = $product_id;
-		$data['app_key'] = $yotpo_settings['app_key'];
-		$_product = wc_get_product( $product_id );
-		if ( is_null( $_product ) || !$_product ) { return; }
-		$yotpo = new Yotpo( $yotpo_settings['app_key'], $yotpo_settings['secret'] );
-		$response = $yotpo->get_product_bottom_line( $data );
-		if ( !empty( $response ) ) {
-			if ( $response['status']['code'] && $response['status']['code'] === 200 && $response['response']['bottomline']['total_reviews'] > 0 ) {
-				$widget_product_data = wc_yotpo_get_product_data( wc_get_product( $product_id ) );
-				$html = "<div class='yotpo bottomLine'
+		$product_handler     = YRFW_Product_Cache::get_instance();
+		$widget_product_data = $product_handler->get_cached_product( $product_id );
+		$html                = "<div class='yotpo yotpo-main-widget'
 							data-product-id='{$product_id}'
-			   				data-url='{$widget_product_data['url']}'
-			   				data-lang='{$widget_product_data['lang']}'>
-		   				</div>";
-			} elseif ( !isset( $args['0'] ) || $args['0'] != "noempty"  ) {
+							data-name='{$widget_product_data['name']}'
+							data-url='{$widget_product_data['url']}'
+							data-image-url='{$widget_product_data['image']}'
+							data-description='{$widget_product_data['description']}'
+							data-lang='{$widget_product_data['lang']}'
+							data-price='{$widget_product_data['price']}'
+							data-currency='" . get_woocommerce_currency() . "'></div>";
+		return $html;
+	}
+
+	/**
+	 * Show star rating widget
+	 *
+	 * @param array $args product_id argument.
+	 * @return string
+	 */
+	public function yotpo_bottomline( $args ) {
+		if ( ! class_exists( 'YRFW_API_Wrapper' ) ) {
+			require_once YRFW_PLUGIN_PATH . 'inc/Helpers/class-yrfw-api-wrapper.php';
+		}
+		if ( ! array_key_exists( 'settings_instance', $GLOBALS ) ) {
+			$settings_instance = ( YRFW_Settings_File::get_instance() )->get_settings();
+		} else {
+			global $settings_instance;
+		}
+		if ( isset( $args['product_id'] ) ) {
+			$product_id = $args['product_id'];
+		} elseif ( is_product() ) {
+			global $product;
+			$product_id = $product->get_id();
+		} else {
+			return;
+		}
+		$curl = YRFW_API_Wrapper::get_instance();
+		$curl->init( $settings_instance['app_key'], $settings_instance['secret'] );
+		$response = json_decode( $curl->get_bottomline( $product_id ) );
+		if ( ! empty( $response ) ) {
+			if ( $response->response->bottomline->total_reviews > 0 ) {
+				$product_handler     = YRFW_Product_Cache::get_instance();
+				$widget_product_data = $product_handler->get_cached_product( $product_id );
+				$html                = "<div class='yotpo bottomLine'
+									data-product-id='{$product_id}'
+									data-url='{$widget_product_data['url']}'
+									data-lang='{$widget_product_data['lang']}'>
+									</div>";
+			} elseif ( ! isset( $args['0'] ) || 'noempty' !== $args['0'] ) {
 				return $this->show_empty_bottomline();
-			} else { return; }
+			} else {
+				return;
+			}
 		}
 		return $html;
 	}
 
-	public function show_empty_bottomline() {
+	/**
+	 * Show empty star rating code
+	 *
+	 * @return string
+	 */
+	private function show_empty_bottomline() {
 		return "<div class='yotpo bottomline'>
 					<div class='yotpo-bottomline pull-left star-clickable'>
 						<span class='yotpo-stars'>
@@ -122,31 +138,47 @@ class Yotpo_Shortcodes
 				</div>";
 	}
 
+	/**
+	 * Show gallery widget
+	 *
+	 * @param array $args arguments accepts 'gallery_id', 'product_id' and 'noproduct'.
+	 * @return string
+	 */
 	public function yotpo_product_gallery( $args ) {
-		$this->basic_check();
 		if ( empty( $args['gallery_id'] ) ) { return 'Error - no gallery ID specified'; }
 		$html = "<div class='yotpo yotpo-pictures-widget' data-gallery-id='{$args['gallery_id']}'";
-		if ( ( !isset($args[0]) || $args[0] != 'noproduct' ) && is_product() ) {
+		if ( ( ! isset( $args[0] ) || 'noproduct' !== $args[0] ) && is_product() ) {
 			global $product;
 			$html .= "data-product-id='{$product->get_id()}'";
-		} elseif ( array_key_exists('product_id', $args) ) {
+		} elseif ( array_key_exists( 'product_id', $args ) ) {
 			$html .= "data-product-id='{$args['product_id']}'";
 		}
-		$html .= "></div>";
+		$html .= '></div>';
 		return $html;
 	}
 
+	/**
+	 * Show reviews carousel widget
+	 *
+	 * @param array $args arguments.
+	 * @return void
+	 */
 	public function yotpo_product_reviews_carousel( $args ) {
-		$this->basic_check();
-		extract( shortcode_atts( array(
-			'background_color' => 'transparent', // transparent or #color
-			'mode' => 'top_rated', // top_rated or most_recent
-			'type' => 'per_product', // per_product, product, both or site
-			'count' => '9', // 3-9
-			'show_bottomline' => '1',
-			'autoplay_enabled' => '1',
-			'autoplay_speed' => '3000',
-			'show_navigation' => '1'), $args ) );
+		extract(
+			shortcode_atts(
+				array(
+					'background_color' => 'transparent', // transparent or #color
+					'mode'             => 'top_rated', // top_rated or most_recent
+					'type'             => 'per_product', // per_product, product, both or site
+					'count'            => '9', // 3-9
+					'show_bottomline'  => '1',
+					'autoplay_enabled' => '1',
+					'autoplay_speed'   => '3000',
+					'show_navigation'  => '1',
+				),
+				$args
+			)
+		);
 		$html = "<div
 			class='yotpo yotpo-reviews-carousel'
 			data-background-color='{$background_color}'
@@ -159,10 +191,10 @@ class Yotpo_Shortcodes
 			data-show-navigation='{$show_navigation}'";
 		if ( isset( $args['product_id'] ) ) {
 			$html .= "data-product-id='{$args['product_id']}'";
-		} elseif ( $mode == 'manual' && isset( $args['review-ids'] ) ) {
+		} elseif ( 'manual' === $mode && isset( $args['review-ids'] ) ) {
 			$html .= "data-review-ids='{$args['review-ids']}'";
-		} elseif ( isset($args[0]) && $args[0] == 'noproduct' ) {
-			$html .= "";
+		} elseif ( isset( $args[0] ) && 'noproduct' === $args[0] ) {
+			$html .= '';
 		} elseif ( is_product() ) {
 			global $product;
 			$html .= "data-product-id='{$product->get_id()}'";
@@ -173,17 +205,25 @@ class Yotpo_Shortcodes
 		return $html;
 	}
 
+	/**
+	 * Show badge widget
+	 *
+	 * @return string
+	 */
 	public function yotpo_badge() {
 		$html = "<div id='y-badges' class='yotpo yotpo-badge badge-init'>&nbsp;</div>";
 		return $html;
 	}
 
+	/**
+	 * Show testimonials widget
+	 *
+	 * @return string
+	 */
 	public function yotpo_testimonials() {
 		$html = "<div id='yotpo-testimonials-custom-tab'></div>";
 		return $html;
 	}
 }
 
-new Yotpo_Shortcodes;
-
-?>
+$shortcodes = new Yotpo_Shortcodes();

--- a/wc_yotpo_shortcodes.php
+++ b/wc_yotpo_shortcodes.php
@@ -99,7 +99,7 @@ class Yotpo_Shortcodes {
 		}
 		$curl = YRFW_API_Wrapper::get_instance();
 		$curl->init( $settings_instance['app_key'], $settings_instance['secret'] );
-		$response = json_decode( $curl->get_bottomline( $product_id ) );
+		$response = json_decode( $curl->get_product_bottomline( $product_id ) );
 		if ( ! empty( $response ) ) {
 			if ( $response->response->bottomline->total_reviews > 0 ) {
 				$product_handler     = YRFW_Product_Cache::get_instance();

--- a/wc_yotpo_shortcodes.php
+++ b/wc_yotpo_shortcodes.php
@@ -106,7 +106,7 @@ class Yotpo_Shortcodes {
 	/**
 	 * Show star rating widget
 	 *
-	 * @param array $args product_id argument.
+	 * @param array $args product_id, noempty arguments.
 	 * @return string
 	 * @since 1.2.0
 	 */
@@ -151,7 +151,7 @@ class Yotpo_Shortcodes {
 	/**
 	 * Show questions widget
 	 *
-	 * @param array $args arguments.
+	 * @param array $args product_id argument.
 	 * @return void | string
 	 * @since 1.2.1
 	 */


### PR DESCRIPTION
### 1.2.1
- Code cleanup.
- Added review highlights widget `[yotpo_highlights]` with optional `product_id` argument.
- Added Q&A widget `[yotpo_questions]` with optional `product_id` argument.
### 1.2.0
- Now using Yotpo Reviews for WooCommerce (YRFW) as requirement.