### PR TITLE
Update to 1.2.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hxii
 Tags: yotpo, shortcode, shortcodes, yotpo add-on, yotpo shortcodes, shortcodes for yotpo
 Requires at least: 4.6
 Requires PHP: 7.0
-Tested up to: 5.3
+Tested up to: 5.5
 Stable tag: 1.2.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hxii
 Tags: yotpo, shortcode, shortcodes, yotpo add-on, yotpo shortcodes, shortcodes for yotpo
 Requires at least: 4.6
 Requires PHP: 7.0
-Tested up to: 5.5
+Tested up to: 5.3
 Stable tag: 1.2.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: yotpo, shortcode, shortcodes, yotpo add-on, yotpo shortcodes, shortcodes f
 Requires at least: 4.6
 Requires PHP: 7.0
 Tested up to: 5.3
-Stable tag: 1.2.2
+Stable tag: 1.2.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,8 @@ Get in touch, and I'll see what can be done.
 == Screenshots ==
 1. Example usage of the shortcodes.
 == Changelog ==
+= 1.2.3 =
+* Tested with WooCommerce 4.1.0-rc.1 and WordPress 5.5-alpha-47623.
 = 1.2.2 =
 * Fixed error when using `[yotpo_bottomline]` wiht a non-existing (in Yotpo) product. 
 = 1.2.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,7 @@ Get in touch, and I'll see what can be done.
 == Changelog ==
 = 1.2.3 =
 * Tested with WooCommerce 4.1.0-rc.1 and WordPress 5.5-alpha-47623.
+* Fixed exception in `yotpo_bottomline` when Yotpo API is unreachable.
 = 1.2.2 =
 * Fixed error when using `[yotpo_bottomline]` wiht a non-existing (in Yotpo) product. 
 = 1.2.1 =

--- a/wc_yotpo_shortcodes.php
+++ b/wc_yotpo_shortcodes.php
@@ -2,12 +2,12 @@
 /*
 * Plugin Name: Shortcodes for Yotpo
 * Description: This plugin adds the ability to use shortcodes to control the placement of Yotpo widgets.
-* Version: 1.2.2
+* Version: 1.2.3
 * Author: Paul Glushak
 * Author URI: http://paulglushak.com/
 * Plugin URI: http://paulglushak.com/shortcodes-for-yotpo/
 * WC requires at least: 3.1.0
-* WC tested up to: 3.8.0
+* WC tested up to: 4.1.0
 */
 
 /*
@@ -130,6 +130,7 @@ class Yotpo_Shortcodes {
 		$curl = YRFW_API_Wrapper::get_instance();
 		$curl->init( $settings_instance['app_key'], $settings_instance['secret'] );
 		$response = json_decode( $curl->get_product_bottomline( $product_id ) );
+		$html     = '';
 		if ( ! empty( $response ) ) {
 			if ( 200 === $response->status->code && $response->response->bottomline->total_reviews > 0 ) {
 				$product_handler     = YRFW_Product_Cache::get_instance();


### PR DESCRIPTION
* Tested with WooCommerce 4.1.0-rc.1 and WordPress 5.5-alpha-47623.
* Fixed exception in `yotpo_bottomline` when Yotpo API is unreachable.